### PR TITLE
Fix: keyboard Navigation Interferes with Multiple Sliders

### DIFF
--- a/src/slider/slider.js
+++ b/src/slider/slider.js
@@ -111,18 +111,18 @@ const Slider = memo(
 						const totalSlides = slideOrder.length;
 						const updated = { ...attributes.slidesPerView };
 						let hasChanges = false;
-				
+
 						['desktop', 'tablet', 'mobile'].forEach((device) => {
 							const current = updated[device] ?? 1;
 							const maxAllowed = Math.max(totalSlides - 1, 1); // always minimum of 1
 							const newVal = Math.min(current, maxAllowed); // auto-restrict if over limit
-				
+
 							if (newVal !== current) {
 								updated[device] = newVal;
 								hasChanges = true;
 							}
 						});
-				
+
 						if (hasChanges) {
 							setAttributes({ slidesPerView: updated });
 						}

--- a/src/slider/swiper-init.js
+++ b/src/slider/swiper-init.js
@@ -85,7 +85,6 @@ export function SwiperInit(
 		},
 		speed: options.speed ?? 300,
 		grabCursor: true,
-		keyboard: true,
 		observer: true,
 		observeParents: true,
 		loop: options.loop ?? false,
@@ -103,6 +102,8 @@ export function SwiperInit(
 		],
 	};
 
+	const swiperInstance = new Swiper(container, parameters);
+
 	// Add breakpoints and universal settings if not in the editor
 	if (!isEditor) {
 		parameters.pagination = { enabled: true, clickable: true };
@@ -111,13 +112,22 @@ export function SwiperInit(
 			nextEl: '.swiper-button-next',
 			prevEl: '.swiper-button-prev',
 		};
+
 		parameters.breakpoints = {
 			320: getDeviceSettings(options, 'Mobile', isFadeEffect, container),
 			480: getDeviceSettings(options, 'Mobile', isFadeEffect, container),
 			768: getDeviceSettings(options, 'Tablet', isFadeEffect, container),
 			1024: getDeviceSettings(options, 'Desktop', isFadeEffect, container),
 		};
+
+		container.addEventListener('focusin', () => {
+			swiperInstance?.keyboard?.enable();
+		});
+		
+		container.addEventListener('focusout', () => {
+			swiperInstance?.keyboard?.disable();
+		});
 	}
 
-	return new Swiper(container, parameters);
+	return swiperInstance;
 }


### PR DESCRIPTION
### Summary
This PR fixes an issue where all slider blocks responded to keyboard arrow keys simultaneously, even when none were focused. Now, only the focused slider responds to left/right arrow keys, improving accessibility and preventing unintended behavior.

### Related Issue
Closes #18 

### Screen Recording

https://github.com/user-attachments/assets/ac146013-24aa-4498-9d83-ea8289b414a0

